### PR TITLE
Seperate the total Metroid count from the required amount

### DIFF
--- a/worlds/am2r/__init__.py
+++ b/worlds/am2r/__init__.py
@@ -1,4 +1,5 @@
 import types
+import logging
 from typing import Dict
 from .items import item_table
 from .locations import get_location_datas, EventId
@@ -8,6 +9,7 @@ from .options import AM2R_options, MetroidsAreChecks
 from worlds.AutoWorld import World, WebWorld
 from worlds.LauncherComponents import Component, components, Type, launch_subprocess
 
+logger = logging.getLogger("AM2R")
 
 def launch_client():
     from .Client import launch
@@ -55,6 +57,8 @@ class AM2RWorld(World):
         return items.create_item(self.player, name)
 
     def create_items(self) -> None:
+        if self.options.MetroidsRequired > self.options.MetroidsInPool:
+            logger.warning(f"Metroid count raised to set requirement for {self.multiworld.get_player_name(self.player)} because the given count was too low for the requirement.")
         if self.options.MetroidsAreChecks != MetroidsAreChecks.option_include_A6:
             self.multiworld.get_location("Deep Caves: Lil\' Bro", self.player).place_locked_item(self.create_item("Metroid"))
             self.multiworld.get_location("Deep Caves: Big Sis", self.player).place_locked_item(self.create_item("Metroid"))

--- a/worlds/am2r/items.py
+++ b/worlds/am2r/items.py
@@ -3,7 +3,7 @@ from collections import Counter
 from typing import Dict, List, NamedTuple, Set
 
 from BaseClasses import Item, ItemClassification, MultiWorld
-from .options import MetroidsAreChecks, MetroidsRequired, get_option_value, TrapFillPercentage, RemoveFloodTrap, RemoveTossTrap, RemoveShortBeam, RemoveEMPTrap, RemoveOHKOTrap, RemoveTouhouTrap
+from .options import MetroidsAreChecks, MetroidsInPool, MetroidsRequired, get_option_value, TrapFillPercentage, RemoveFloodTrap, RemoveTossTrap, RemoveShortBeam, RemoveEMPTrap, RemoveOHKOTrap, RemoveTouhouTrap
 
 
 class ItemData(NamedTuple):
@@ -28,12 +28,14 @@ def create_fixed_item_pool() -> List[str]:
     return list(Counter(required_items).elements())
 
 
-def create_metroid_items(MetroidsRequired: MetroidsRequired, MetroidsAreChecks: MetroidsAreChecks) -> List[str]:
+def create_metroid_items(MetroidsRequired: MetroidsRequired, MetroidsInPool: MetroidsInPool, MetroidsAreChecks: MetroidsAreChecks) -> List[str]:
     metroid_count = 0
+    if MetroidsRequired > MetroidsInPool:
+        MetroidsInPool = MetroidsRequired
     if MetroidsAreChecks == MetroidsAreChecks.option_include_A6:
-        metroid_count = MetroidsRequired.value
+        metroid_count = MetroidsInPool.value
     elif MetroidsAreChecks == MetroidsAreChecks.option_exclude_A6:
-        metroid_count += MetroidsRequired.value - 5
+        metroid_count = MetroidsInPool.value - 5
     return ["Metroid" for _ in range(metroid_count)]
 
 
@@ -80,7 +82,7 @@ def create_all_items(multiworld: MultiWorld, player: int) -> None:
 
     itempool = (
         create_fixed_item_pool()
-        + create_metroid_items(multiworld.MetroidsRequired[player], multiworld.MetroidsAreChecks[player])
+        + create_metroid_items(multiworld.MetroidsRequired[player], multiworld.MetroidsInPool[player], multiworld.MetroidsAreChecks[player])
     )
 
     trap_percentage = get_option_value(multiworld, player, "TrapFillPercentage")

--- a/worlds/am2r/options.py
+++ b/worlds/am2r/options.py
@@ -4,8 +4,16 @@ from Options import AssembleOptions, Choice, DeathLink, DefaultOnToggle, Range, 
 
 
 class MetroidsRequired(Range):
-    """Chose how many Metroids need to be killed or obtained to go through to the omega nest"""
+    """Chose how many Metroids need to be killed or obtained to go through to the Omega Nest"""
     display_name = "Metroids Required for Omega Nest"
+    range_start = 0
+    range_end = 46
+    default = 46
+
+
+class MetroidsInPool(Range):
+    """Chose how many Metroids will be in the pool, if Metroids are randomized. This will value will be ignored if smaller than the required amount"""
+    display_name = "Total Metroids in Pool"
     range_start = 0
     range_end = 46
     default = 46
@@ -109,6 +117,7 @@ class RemoveOHKOTrap(Toggle):
 
 AM2R_options: Dict[str, AssembleOptions] = {
     "MetroidsRequired": MetroidsRequired,
+    "MetroidsInPool": MetroidsInPool,
     "MetroidsAreChecks": MetroidsAreChecks,
     "TrapFillPercentage": TrapFillPercentage,
     "RemoveFloodTrap": RemoveFloodTrap,


### PR DESCRIPTION
## What is this fixing or adding?
This change adds a new option to allow for higher Metroid counts than the requirement set in the yaml.
It checks to see if the setting is lower than the requirement and fixes it if necessary, and will put a message in the generation log saying as such.

## How was this tested?
Ran a few test generations.